### PR TITLE
fix: Implemento mensaje si no se encuentra un post

### DIFF
--- a/client/src/Components/FollowBar/FollowBar.tsx
+++ b/client/src/Components/FollowBar/FollowBar.tsx
@@ -6,8 +6,10 @@ import { useState } from "react";
 
 export default function FollowBar() {
   const [more, setMore] = useState(false);
-  const seguidos =
-    useSelector((state: IState) => state.profile?.following) || [];
+  const { profile, post } =
+    useSelector((state: IState) => state) || [];
+
+  const seguidos = profile?.following || post?.author?.following || []
 
   return (
     <div className="followBar">
@@ -22,7 +24,7 @@ export default function FollowBar() {
             )
           )
         ) : (
-          <h3>No sigues a nadie aún.</h3>
+          <h3>No tiene seguidos aún.</h3>
         )}
       </div>
       {seguidos?.length > 3 && !more && (

--- a/client/src/Components/Post/Post.tsx
+++ b/client/src/Components/Post/Post.tsx
@@ -1,4 +1,4 @@
-import React, { useState, FC, useRef } from "react";
+import React, { useState, FC, useRef, useEffect } from "react";
 import { FaBan } from "react-icons/fa";
 import { BsThreeDots, BsChatSquareDots } from "react-icons/bs";
 import style from "./Post.module.scss";
@@ -74,12 +74,17 @@ const Post: FC<Props> = ({ post }) => {
     if(redirect){ navigate("/")}
   }
 
+  useEffect(() => {
+    console.log(post?._id);
+  }, [post])
+  
+
   return (
     <div 
       className={style.postContainer}
       style={{display: eliminated ? 'none' : 'block'}}
     >
-      {!post?._id ? 
+      {post?._id === false ? 
       <h2 style={{textAlign: 'center', color: 'white'}}>Esta publicación ya ha sido eliminada.</h2>
       : post ?
       <div

--- a/client/src/Pages/PostDetail/PostDetail.tsx
+++ b/client/src/Pages/PostDetail/PostDetail.tsx
@@ -47,16 +47,3 @@ export default function PostDetail() {
     </>
   );
 }
-
-/* 
-
-Datos que tengo que recibir en este componente:
-
--Los detalles del Post:
-
-  Nombre, fecha de publicacion, contenido del post, 
-  numero de likes y comentarios, 
-  arreglo de objetos con cada uno de los comentarios:
-  { name, content, date, cohorte(opc), countLikes} 
-
-*/

--- a/client/src/redux/actions/actions.tsx
+++ b/client/src/redux/actions/actions.tsx
@@ -117,13 +117,19 @@ export function searchUsers(username: string) {
 export function getPost(id: String) {
   return function (dispatch: Function) {
     axios.get("/post/" + id).then((post) => {
-      if (post)
+      if (post.data){
         axios.get("/comments/" + post.data._id).then((comments) => {
           return dispatch({
             type: GET_POST,
             payload: { post: post.data, comments: comments.data },
           });
+        });}
+      else {
+        return dispatch({
+          type: GET_POST,
+          payload: { post: {_id: false}, comments: [] },
         });
+      }
     });
   };
 }

--- a/src/models/Post.ts
+++ b/src/models/Post.ts
@@ -8,7 +8,7 @@ export interface IPost {
   nLikes: [string];
   numComments: number;
   author: IUser;
-  _id: number;
+  _id: number | boolean;
   typePost: string;
   company: string;
   position: string;


### PR DESCRIPTION
- Se añadió un mensaje si el post en los detalles del post no se encuentra.
- Se mejoró el followBar para que se visualice los seguidos tanto del perfil del usuario como en su post.
- Se arreglo el bug de denunciar un post nuestro, evitando eso con eliminar el post si es nuestro.